### PR TITLE
Fix package installation

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Install SSHFS
-  apt: pkg=sshfs state=installed update_cache=true
+  apt: pkg=sshfs state=present update_cache=true
   become: yes
 
 - name: Unmount (fusermount) Media Directory


### PR DESCRIPTION
Changed task parameter for package installation since it produces errors:

```
TASK [amritsingh.sshfs : Install SSHFS] ********************************************************************************
fatal: [buzz]: FAILED! => {"ansible_facts": {"discovered_interpreter_python": "/usr/bin/python3"}, "changed": false, "msg":
 "value of state must be one of: absent, build-dep, fixed, latest, present, got: installed"}
```